### PR TITLE
Add Fidelity Rewards transaction schema

### DIFF
--- a/postgres/fidelityrewards.transactions.sql
+++ b/postgres/fidelityrewards.transactions.sql
@@ -1,0 +1,33 @@
+-- Table: fidelityrewards.transactions
+
+-- DROP TABLE fidelityrewards.transactions;
+
+CREATE TABLE fidelityrewards.transactions
+(
+    id bigint NOT NULL DEFAULT nextval('fidelityrewards.transactions_id_seq'::regclass),
+    transaction_date date NOT NULL,
+    type character varying COLLATE pg_catalog."default" NOT NULL,
+    name character varying(80) COLLATE pg_catalog."default" NOT NULL,
+    memo character varying(80) COLLATE pg_catalog."default" NOT NULL,
+    amount numeric(10,2) NOT NULL,
+    entity_id bigint,
+    created_by_id bigint,
+    CONSTRAINT transactions_pkey PRIMARY KEY (id),
+    CONSTRAINT created_by_id FOREIGN KEY (created_by_id)
+        REFERENCES public.users (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+        NOT VALID,
+    CONSTRAINT entity_id FOREIGN KEY (entity_id)
+        REFERENCES public.entities (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+        NOT VALID
+)
+WITH (
+    OIDS = FALSE
+)
+TABLESPACE pg_default;
+
+ALTER TABLE fidelityrewards.transactions
+    OWNER to postgres;

--- a/postgres/public.entities.sql
+++ b/postgres/public.entities.sql
@@ -1,0 +1,23 @@
+-- Table: public.entities
+
+-- DROP TABLE public.entities;
+
+CREATE TABLE public.entities
+(
+    name character varying(255) COLLATE pg_catalog."default" NOT NULL,
+    id bigint NOT NULL DEFAULT nextval('entities_id_seq'::regclass),
+    owner_id bigint NOT NULL,
+    CONSTRAINT entities_pkey PRIMARY KEY (id),
+    CONSTRAINT owner_id FOREIGN KEY (owner_id)
+        REFERENCES public.users (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE RESTRICT
+        NOT VALID
+)
+WITH (
+    OIDS = FALSE
+)
+TABLESPACE pg_default;
+
+ALTER TABLE public.entities
+    OWNER to postgres;

--- a/postgres/public.users.sql
+++ b/postgres/public.users.sql
@@ -1,0 +1,20 @@
+-- Table: public.users
+
+-- DROP TABLE public.users;
+
+CREATE TABLE public.users
+(
+    first_name character varying(40) COLLATE pg_catalog."default",
+    last_name character varying(40) COLLATE pg_catalog."default" NOT NULL,
+    username character varying(255) COLLATE pg_catalog."default" NOT NULL,
+    id bigint NOT NULL DEFAULT nextval('users_id_seq'::regclass),
+    CONSTRAINT users_pkey PRIMARY KEY (id),
+    CONSTRAINT username UNIQUE (username)
+)
+WITH (
+    OIDS = FALSE
+)
+TABLESPACE pg_default;
+
+ALTER TABLE public.users
+    OWNER to postgres;


### PR DESCRIPTION
This pr resolves #1 by defining the expected schema which supports the ability to download a CSV file of transactions from the [Fidelity® Rewards Visa Signature® Credit Card][1] site and (as a database admin) manually import the file into a table in the PostgreSQL database.

For this implementation since there's no GUI for importing data, the `fidelityrewards.transactions.entity_id` and `fidelityrewards.transactions.created_by_id` fields may be empty.

[1]: http://www.fidelityrewards.com/credit/welcome.do